### PR TITLE
Fixed NPE when logging in with an item inventory (#9)

### DIFF
--- a/src/main/java/com/advancedmining/AdvancedMiningPlugin.java
+++ b/src/main/java/com/advancedmining/AdvancedMiningPlugin.java
@@ -206,22 +206,24 @@ public class AdvancedMiningPlugin extends Plugin {
 	@Subscribe
 	public void onGameTick(GameTick gameTick) {
 		if (recentlyLoggedIn) {
-				final ItemContainer itemContainer = client.getItemContainer(InventoryID.INVENTORY);
+			final ItemContainer itemContainer = client.getItemContainer(InventoryID.INVENTORY);
+			if (itemContainer != null) {
 				final Item[] items = itemContainer.getItems();
-					for (Item i : items) {
-						if (i.getId() == ItemID.BLESSED_BONE_SHARDS) {
-							previousAmount = i.getQuantity();
-							recentlyLoggedIn = false;
-						}
-						if (i.getId() == ItemID.STARDUST) {
-							previousAmount = i.getQuantity();
-							recentlyLoggedIn = false;
-						}
-						if (i.getId() == ItemID.BARRONITE_SHARDS) {
-							previousAmount = i.getQuantity();
-							recentlyLoggedIn = false;
-						}
+				for (Item i : items) {
+					if (i.getId() == ItemID.BLESSED_BONE_SHARDS) {
+						previousAmount = i.getQuantity();
+						recentlyLoggedIn = false;
 					}
+					if (i.getId() == ItemID.STARDUST) {
+						previousAmount = i.getQuantity();
+						recentlyLoggedIn = false;
+					}
+					if (i.getId() == ItemID.BARRONITE_SHARDS) {
+						previousAmount = i.getQuantity();
+						recentlyLoggedIn = false;
+					}
+				}
+			}
 		}
 		clearExpiredRespawns();
 		recentlyLoggedIn = false;


### PR DESCRIPTION
When logging in to OSRS with an empty inventory, NPE's keep getting thrown until you initialize the item container by modifying your inventory in some way (eg. adding something to it). The solution I implemented was to do a simple null check before attempting to call #ItemContainer#getItems which was throwing the NPE.

Closes #9 